### PR TITLE
different format for external links

### DIFF
--- a/ox-mediawiki.el
+++ b/ox-mediawiki.el
@@ -330,8 +330,8 @@ a communication channel."
 			    (if (not (file-name-absolute-p raw-path)) raw-path
 			      (concat "file://" (expand-file-name raw-path))))
 			   (t raw-path))))
-	       (if (not contents) (format "<%s>" path)
-		 (format "[%s](%s)" contents path)))))))
+	       (if (not contents) (format "%s" path)
+		 (format "[%s %s]" path contents)))))))
 
 
 ;;;; Paragraph


### PR DESCRIPTION
hi ... if a description is given for an external link i want this to show also in the mediawiki markup.
i understand that mediawiki does not support all kinds of links, but this looks good to me: http://www.mediawiki.org/wiki/Help:Links#External_links
