### PR TITLE
Add support for footnotes

### DIFF
--- a/ox-mediawiki.el
+++ b/ox-mediawiki.el
@@ -50,14 +50,25 @@ This variable can be set to either `atx' or `setext'."
 	  (const :tag "Use \"Setext\" style" setext)))
 
 ;;Define the default table class
-(defvar org-mw-default-table-class "wikitable"
-  "Non-nil  means that  the mediaWiki  exporter should  specify a
-   class name for this exported  table. Setting this to nil means
-   to exclude any class definition.")
+(defcustom org-mw-default-table-class "wikitable"
+  "Non-nil means that the mediaWiki exporter should specify a class
+name for this exported table. Setting this to nil means to exclude
+any class definition."
+  :group 'org-export-mw
+  :type 'string)
 
+;;
+;; Footnotes.
+;;
+;; TODO: Currently footnotes are just exported as plain text. It would be really
+;;        nice if we have a variable that let the user tell us if they wanted to
+;;        export using the Cite syntax for footnotes.
+;;
+;;        http://www.mediawiki.org/wiki/Help:Extension:Cite
+;;
 (defcustom org-mw-footnote-format "[%s]"
   "The format for the footnote reference.
-   %s will be replaced by the footnote reference itself."
+%s will be replaced by the footnote reference itself."
   :group 'org-export-mw
   :type 'string)
 
@@ -66,7 +77,7 @@ This variable can be set to either `atx' or `setext'."
   :group 'org-export-mw
   :type 'string)
 
-(defcustom org-mw-footnotes-section "= %s =\n%s"
+(defcustom org-mw-footnotes-section "\n----\n=== %s ===\n%s"
   "Format for the footnotes section.
 Should contain a two instances of %s.  The first will be replaced with the
 language-specific word for \"Footnotes\", the second one will be replaced
@@ -129,9 +140,8 @@ by the footnotes themselves."
           n))
 
 (defun org-mw-footnote-reference (footnote-reference contents info)
-  "Transcode  a  FOOTNOTE-REFERENCE  element   from  Org  to  MW.
-   CONTENTS  is   nil.   INFO  is  a   plist  holding  contextual
-   information."
+  "Transcode a FOOTNOTE-REFERENCE element from Org to MW.  CONTENTS is nil.
+INFO is a plist holding contextual information."
   (concat
    ;; Insert separator between two footnotes in a row.
    (let ((prev (org-export-get-previous-element footnote-reference info)))
@@ -154,7 +164,7 @@ by the footnotes themselves."
 
 (defun org-mw--translate (s info)
   "Translate string S according to specified language.
-   INFO is a plist used as a communication channel."
+INFO is a plist used as a communication channel."
   (org-export-translate s :ascii info))
 
 (defun org-mw-format-footnotes-section (section-name definitions)
@@ -171,7 +181,7 @@ by the footnotes themselves."
 
 (defun org-mw-footnote-section (info)
   "Format the footnote section.
-   INFO is a plist used as a communication channel."
+INFO is a plist used as a communication channel."
   (let* ((fn-alist (org-export-collect-footnote-definitions
 		    (plist-get info :parse-tree) info))
 	 (fn-alist


### PR DESCRIPTION
This changes does two things:

1) It adds a custom var to hold the class for wikimedia tables. I made the default, 'wikitable' which seems to be supported and produces a nice table (see screen shot). I could see making the default 'nil' if you want.

2) This diff adds basic support for footnotes for this ticket:  https://github.com/craftkiller/orgmode-mediawiki/issues/5

Here is a test ORG file I used, its markup output after export and a screen shot of what the exported mark up looks like on a wiki page.

Thanks,
--greg.
## Sample Org File

<pre>
* Main Section

  Hi, this  is going to test  footnotes[fn:footnote]. That last one  was a named
  footnote, this one[fn:1] is a numbered footnote.

** sub section
   Now, here comes an inline footnote[fn:: defined inline] and the next one will
   be the alternate version of the inlined footnote[fn:alternate: An alternate style linline].

   That is all. Please move along.

#+CAPTION: [tester]{A table showing stuff.}
#+LABEL: tab:value-tables
#+ATTR_LATEX: :environment longtable
# #+NAME:value-tables   
|---------------+-------+-------+--------+-------------|
| Website Title | Price | Value | Orders | Total Value |
|---------------+-------+-------+--------+-------------|
| One Year      |    99 |  1188 |  28000 |    33264000 |
| test one      |    69 |  1400 |  19000 |    26600000 |
| test two      |    69 |  1400 |  18800 |    26320000 |

* Footnotes

[fn:footnote] this one works.

[fn:1] and this one too.

</pre>

## Exported markup from example org file.

<pre>
= Main Section =
Hi, this  is going to test  footnotes[1]. That last one  was a named
footnote, this one[2] is a numbered footnote.

== sub section ==
Now, here comes an inline footnote[3] and the next one will
be the alternate version of the inlined footnote[4].

That is all. Please move along.


{| class=wikitable






|-

|-
|Website Title
|Price
|Value
|Orders
|Total Value

|-

|-
|One Year
|99
|1188
|28000
|33264000

|-
|test one
|69
|1400
|19000
|26600000

|-
|test two
|69
|1400
|18800
|26320000

|}

----
=== Footnotes ===

[1] this one works.

[2] and this one too.

[3] defined inline

[4] An alternate style linline

</pre>

## Screen Shot of markup

![screen shot 2013-12-24 at 9 23 07 am](https://f.cloud.github.com/assets/1823356/1806839/f5c47504-6cc0-11e3-862c-f2f97441a3ba.png)
