### PR TITLE
Fix list, link, and underline exports.

### DIFF
--- a/ox-mediawiki.el
+++ b/ox-mediawiki.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2012, 2013  Free Software Foundation, Inc.
 
 ;; Author: Tom Alexander <tomalexander@paphus.com>
+;; Author: Tim Visher <tim.visher@gmail.com>
 ;; Keywords: org, wp, mediawiki
 
 ;; GNU Emacs is free software: you can redistribute it and/or modify
@@ -46,8 +47,8 @@
 This variable can be set to either `atx' or `setext'."
   :group 'org-export-mw
   :type '(choice
-	  (const :tag "Use \"atx\" style" atx)
-	  (const :tag "Use \"Setext\" style" setext)))
+          (const :tag "Use \"atx\" style" atx)
+          (const :tag "Use \"Setext\" style" setext)))
 
 ;;Define the default table class
 (defcustom org-mw-default-table-class "wikitable"
@@ -94,42 +95,41 @@ by the footnotes themselves."
   :menu-entry
   '(?m "Export to Mediawiki"
        ((?M "To temporary buffer"
-	    (lambda (a s v b) (org-mw-export-as-mediawiki a s v)))
-	(?m "To file" (lambda (a s v b) (org-mw-export-to-mediawiki a s v)))
-	(?o "To file and open"
-	    (lambda (a s v b)
-	      (if a (org-mw-export-to-mediawiki t s v)
-		(org-open-file (org-mw-export-to-mediawiki nil s v)))))))
+            (lambda (a s v b) (org-mw-export-as-mediawiki a s v)))
+        (?m "To file" (lambda (a s v b) (org-mw-export-to-mediawiki a s v)))
+        (?o "To file and open"
+            (lambda (a s v b)
+              (if a (org-mw-export-to-mediawiki t s v)
+                (org-open-file (org-mw-export-to-mediawiki nil s v)))))))
   :translate-alist '((bold . org-mw-bold)
-		     (code . org-mw-verbatim)
-		     (underline . org-mw-verbatim)
-		     (comment . (lambda (&rest args) ""))
-		     (comment-block . (lambda (&rest args) ""))
-		     (example-block . org-mw-example-block)
-		     (fixed-width . org-mw-example-block)
-		     (footnote-definition . ignore)
-		     (footnote-reference . org-mw-footnote-reference)
-		     (headline . org-mw-headline)
-		     (horizontal-rule . org-mw-horizontal-rule)
-		     (inline-src-block . org-mw-verbatim)
-		     (italic . org-mw-italic)
-		     (item . org-mw-item)
-		     (line-break . org-mw-line-break)
-		     (link . org-mw-link)
-		     (paragraph . org-mw-paragraph)
-		     (plain-list . org-mw-plain-list)
-		     (plain-text . org-mw-plain-text)
-		     (quote-block . org-mw-quote-block)
-		     (quote-section . org-mw-example-block)
-		     (section . org-mw-section)
-		     (src-block . org-mw-example-block)
-		     (inner-template . org-mw-inner-template)
-		     (template . org-mw-template)
-		     (verbatim . org-mw-verbatim)
-             (table . org-mw-table)
-             (table-cell . org-mw-table-cell)
-             (table-row . org-mw-table-row)
-             ))
+                     (code . org-mw-verbatim)
+                     (underline . org-mw-verbatim)
+                     (comment . (lambda (&rest args) ""))
+                     (comment-block . (lambda (&rest args) ""))
+                     (example-block . org-mw-example-block)
+                     (fixed-width . org-mw-example-block)
+                     (footnote-definition . ignore)
+                     (footnote-reference . org-mw-footnote-reference)
+                     (headline . org-mw-headline)
+                     (horizontal-rule . org-mw-horizontal-rule)
+                     (inline-src-block . org-mw-verbatim)
+                     (italic . org-mw-italic)
+                     (item . org-mw-item)
+                     (line-break . org-mw-line-break)
+                     (link . org-mw-link)
+                     (paragraph . org-mw-paragraph)
+                     (plain-list . org-mw-plain-list)
+                     (plain-text . org-mw-plain-text)
+                     (quote-block . org-mw-quote-block)
+                     (quote-section . org-mw-example-block)
+                     (section . org-mw-section)
+                     (src-block . org-mw-example-block)
+                     (inner-template . org-mw-inner-template)
+                     (template . org-mw-template)
+                     (verbatim . org-mw-verbatim)
+                     (table . org-mw-table)
+                     (table-cell . org-mw-table-cell)
+                     (table-row . org-mw-table-row)))
 
 ;;
 ;; Footnote support
@@ -159,8 +159,8 @@ INFO is a plist holding contextual information."
       "IGNORED" 1))
     ;; Non-inline footnotes definitions are full Org data.
     (t (org-mw-format-footnote-reference
-	(org-export-get-footnote-number footnote-reference info)
-	"IGNORED" 1)))))
+        (org-export-get-footnote-number footnote-reference info)
+        "IGNORED" 1)))))
 
 (defun org-mw--translate (s info)
   "Translate string S according to specified language.
@@ -183,19 +183,19 @@ INFO is a plist used as a communication channel."
   "Format the footnote section.
 INFO is a plist used as a communication channel."
   (let* ((fn-alist (org-export-collect-footnote-definitions
-		    (plist-get info :parse-tree) info))
-	 (fn-alist
-	  (loop for (n type raw) in fn-alist collect
-		(cons n (if (eq (org-element-type raw) 'org-data)
-			    (org-trim (org-export-data raw info))
-			  (format "%s"
-				  (org-trim (org-export-data raw info))))))))
+                    (plist-get info :parse-tree) info))
+         (fn-alist
+          (loop for (n type raw) in fn-alist collect
+                (cons n (if (eq (org-element-type raw) 'org-data)
+                            (org-trim (org-export-data raw info))
+                          (format "%s"
+                                  (org-trim (org-export-data raw info))))))))
     (when fn-alist
       (org-mw-format-footnotes-section
        (org-mw--translate "Footnotes" info)
        (format
-	"\n%s\n"
-	(mapconcat 'org-mw-format-footnote-definition fn-alist "\n"))))))
+        "\n%s\n"
+        (mapconcat 'org-mw-format-footnote-definition fn-alist "\n"))))))
 
 ;;; Filters
 (defun org-mw-separate-elements (tree backend info)
@@ -208,10 +208,10 @@ Assume BACKEND is `mw'."
   (org-element-map tree org-element-all-elements
     (lambda (elem)
       (unless (eq (org-element-type elem) 'org-data)
-	(org-element-put-property
-	 elem :post-blank
-	 (let ((post-blank (org-element-property :post-blank elem)))
-	   (if (not post-blank) 1 (max 1 post-blank)))))))
+        (org-element-put-property
+         elem :post-blank
+         (let ((post-blank (org-element-property :post-blank elem)))
+           (if (not post-blank) 1 (max 1 post-blank)))))))
   ;; Return updated tree.
   tree)
 
@@ -233,14 +233,12 @@ a communication channel."
   "Transcode VERBATIM object into Mediawiki format.
 CONTENTS is nil.  INFO is a plist used as a communication
 channel."
-  (let ((value (org-element-property :value verbatim)))
-    (format (cond ((not (string-match "`" value)) "`%s`")
-		  ((or (string-match "\\``" value)
-		       (string-match "`\\'" value))
-		   "<code> %s </code>")
-		  (t "<code>%s</code>"))
-	    value)))
-
+  (format (cond ((not (string-match "`" contents)) "`%s`")
+                ((or (string-match "\\``" contents)
+                     (string-match "`\\'" contents))
+                 "<code> %s </code>")
+                (t "<code>%s</code>"))
+          contents))
 
 ;;;; Example Block and Src Block
 
@@ -285,19 +283,6 @@ a communication channel."
            (heading (concat todo priority title))) ;; End of Let*
 
       (cond
-       ;; Cannot create a headline.  Fall-back to a list.
-       ;; ((or (org-export-low-level-p headline info)
-       ;;      (not (memq org-mw-headline-style '(atx setext)))
-       ;;      (and (eq org-mw-headline-style 'atx) (> level 6))
-       ;;      (and (eq org-mw-headline-style 'setext) (> level 2)))
-       ;;  (let ((bullet
-       ;;         (if (not (org-export-numbered-headline-p headline info)) "*"
-       ;;           "#")))
-       ;;    (concat bullet (make-string (- 4 (length bullet)) ? ) heading tags
-       ;;            "\n\n"
-       ;;            (and contents
-       ;;                 (replace-regexp-in-string "^" "    " contents)))))
-
        ;; Use "Setext" style.
        ((eq org-mw-headline-style 'setext)
         (concat heading tags "\n"
@@ -334,21 +319,9 @@ a communication channel."
   (let* ((type (org-element-property :type (org-export-get-parent item)))
          (struct (org-element-property :structure item))
          (bullet (if (not (eq type 'ordered)) "*"
-                   "#")))
-    (mapconcat (lambda (line) (if (string-match "^[ \t]*$" line) "" (concat bullet line "\n")))
-               (split-string
-                (concat
-                 " "
-                 (case (org-element-property :checkbox item)
-                   (on "☑ ")
-                   (trans "<code>[-]</code> ")
-                   (off "☐ "))
-                 (let ((tag (org-element-property :tag item)))
-                   (and tag (format "**%s:** "(org-export-data tag info))))
-                 (org-trim contents)
-                 )
-                "\n") "")
-    ))
+                   "#"))
+         (the-item (s-join "\n  " (s-split "\n" (org-trim contents)))))
+    (format "%s %s" bullet the-item)))
 
 ;;;; Line Break
 
@@ -365,74 +338,74 @@ channel."
 CONTENTS is the link's description.  INFO is a plist used as
 a communication channel."
   (let ((--link-org-files-as-html-maybe
-	 (function
-	  (lambda (raw-path info)
-	    ;; Treat links to `file.org' as links to `file.html', if
+         (function
+          (lambda (raw-path info)
+            ;; Treat links to `file.org' as links to `file.html', if
             ;; needed.  See `org-html-link-org-files-as-html'.
-	    (cond
-	     ((and org-html-link-org-files-as-html
-		   (string= ".org"
-			    (downcase (file-name-extension raw-path "."))))
-	      (concat (file-name-sans-extension raw-path) "."
-		      (plist-get info :html-extension)))
-	     (t raw-path)))))
-	(type (org-element-property :type link)))
+            (cond
+             ((and org-html-link-org-files-as-html
+                   (string= ".org"
+                            (downcase (file-name-extension raw-path "."))))
+              (concat (file-name-sans-extension raw-path) "."
+                      (plist-get info :html-extension)))
+             (t raw-path)))))
+        (type (org-element-property :type link)))
     (cond ((member type '("custom-id" "id"))
-	   (let ((destination (org-export-resolve-id-link link info)))
-	     (if (stringp destination)	; External file.
-		 (let ((path (funcall --link-org-files-as-html-maybe
-				      destination info)))
-		   (if (not contents) (format "<%s>" path)
-		     (format "[%s](%s)" contents path)))
-	       (concat
-		(and contents (concat contents " "))
-		(format "(%s)"
-			(format (org-export-translate "See section %s" :html info)
-				(mapconcat 'number-to-string
-					   (org-export-get-headline-number
-					    destination info)
-					   ".")))))))
-	  ((org-export-inline-image-p link org-html-inline-image-rules)
-	   (let ((path (let ((raw-path (org-element-property :path link)))
-			 (if (not (file-name-absolute-p raw-path)) raw-path
-			   (expand-file-name raw-path)))))
-	     (format "![%s](%s)"
-		     (let ((caption (org-export-get-caption
-				     (org-export-get-parent-element link))))
-		       (when caption (org-export-data caption info)))
-		     path)))
-	  ((string= type "coderef")
-	   (let ((ref (org-element-property :path link)))
-	     (format (org-export-get-coderef-format ref contents)
-		     (org-export-resolve-coderef ref info))))
-	  ((equal type "radio")
-	   (let ((destination (org-export-resolve-radio-link link info)))
-	     (org-export-data (org-element-contents destination) info)))
-	  ((equal type "fuzzy")
-	   (let ((destination (org-export-resolve-fuzzy-link link info)))
-	     (if (org-string-nw-p contents) contents
-	       (when destination
-		 (let ((number (org-export-get-ordinal destination info)))
-		   (when number
-		     (if (atom number) (number-to-string number)
-		       (mapconcat 'number-to-string number "."))))))))
-	  (t (let* ((raw-path (org-element-property :path link))
-		    (path (cond
-			   ((member type '("http" "https" "ftp"))
-			    (concat type ":" raw-path))
-			   ((equal type "file")
-			    ;; Treat links to ".org" files as ".html",
-			    ;; if needed.
-			    (setq raw-path
-				  (funcall --link-org-files-as-html-maybe
-					   raw-path info))
-			    ;; If file path is absolute, prepend it
-			    ;; with protocol component - "file://".
-			    (if (not (file-name-absolute-p raw-path)) raw-path
-			      (concat "file://" (expand-file-name raw-path))))
-			   (t raw-path))))
-	       (if (not contents) (format "%s" path)
-		 (format "[%s %s]" path contents)))))))
+           (let ((destination (org-export-resolve-id-link link info)))
+             (if (stringp destination)	; External file.
+                 (let ((path (funcall --link-org-files-as-html-maybe
+                                      destination info)))
+                   (if (not contents) (format "<%s>" path)
+                     (format "[%s](%s)" contents path)))
+               (concat
+                (and contents (concat contents " "))
+                (format "(%s)"
+                        (format (org-export-translate "See section %s" :html info)
+                                (mapconcat 'number-to-string
+                                           (org-export-get-headline-number
+                                            destination info)
+                                           ".")))))))
+          ((org-export-inline-image-p link org-html-inline-image-rules)
+           (let ((path (let ((raw-path (org-element-property :path link)))
+                         (if (not (file-name-absolute-p raw-path)) raw-path
+                           (expand-file-name raw-path)))))
+             (format "![%s](%s)"
+                     (let ((caption (org-export-get-caption
+                                     (org-export-get-parent-element link))))
+                       (when caption (org-export-data caption info)))
+                     path)))
+          ((string= type "coderef")
+           (let ((ref (org-element-property :path link)))
+             (format (org-export-get-coderef-format ref contents)
+                     (org-export-resolve-coderef ref info))))
+          ((equal type "radio")
+           (let ((destination (org-export-resolve-radio-link link info)))
+             (org-export-data (org-element-contents destination) info)))
+          ((equal type "fuzzy")
+           (let ((destination (org-export-resolve-fuzzy-link link info)))
+             (if (org-string-nw-p contents) contents
+               (when destination
+                 (let ((number (org-export-get-ordinal destination info)))
+                   (when number
+                     (if (atom number) (number-to-string number)
+                       (mapconcat 'number-to-string number "."))))))))
+          (t (let* ((raw-path (org-element-property :path link))
+                    (path (cond
+                           ((member type '("http" "https" "ftp"))
+                            (concat type ":" raw-path))
+                           ((equal type "file")
+                            ;; Treat links to ".org" files as ".html",
+                            ;; if needed.
+                            (setq raw-path
+                                  (funcall --link-org-files-as-html-maybe
+                                           raw-path info))
+                            ;; If file path is absolute, prepend it
+                            ;; with protocol component - "file://".
+                            (if (not (file-name-absolute-p raw-path)) raw-path
+                              (concat "file://" (expand-file-name raw-path))))
+                           (t raw-path))))
+               (if (not contents) (format "%s" path)
+                 (format "[%s %s]" path (s-join " " (s-split "\n" contents)))))))))
 
 
 ;;;; Paragraph
@@ -444,7 +417,7 @@ a communication channel."
   (let ((first-object (car (org-element-contents paragraph))))
     ;; If paragraph starts with a #, protect it.
     (if (and (stringp first-object) (string-match "\\`#" first-object))
-	(replace-regexp-in-string "\\`#" "\\#" contents nil t)
+        (replace-regexp-in-string "\\`#" "\\#" contents nil t)
       contents)))
 
 
@@ -455,7 +428,6 @@ a communication channel."
 CONTENTS is the plain-list contents.  INFO is a plist used as
 a communication channel."
   contents)
-
 
 ;;;; Plain Text
 
@@ -517,10 +489,10 @@ as a communication channel."
   "Return complete document string after Mediawiki conversion.
 CONTENTS is the transcoded contents string.  INFO is a plist used
 as a communication channel."
-    (concat
-     contents
-     ;; Footnotes section.
-     (org-mw-footnote-section info)))
+  (concat
+   contents
+   ;; Footnotes section.
+   (org-mw-footnote-section info)))
 
 ;;;; Tabel Cell
 
@@ -529,27 +501,6 @@ as a communication channel."
 CONTENTS is nil.  INFO is a plist used as a communication
 channel."
   (concat "|" contents "\n"))
-  ;; (let* ((table-row (org-export-get-parent table-cell))
-  ;;    (table (org-export-get-parent-table table-cell))
-  ;;    (cell-attrs
-  ;;     (if (not org-mw-table-align-individual-fields) ""
-  ;;       (format (if (and (boundp 'org-mw-format-table-no-css)
-  ;;   		     org-mw-format-table-no-css)
-  ;;   		" align=\"%s\"" " class=\"%s\"")
-  ;;   	    (org-export-table-cell-alignment table-cell info)))))
-  ;;   (when (or (not contents) (string= "" (org-trim contents)))
-  ;;     (setq contents "&#xa0;"))
-  ;;   (cond
-  ;;    ((and (org-export-table-has-header-p table info)
-  ;;      (= 1 (org-export-table-row-group table-row info)))
-  ;;     (concat "\n" (format (car org-mw-table-header-tags) "col" cell-attrs)
-  ;;         contents (cdr org-mw-table-header-tags)))
-  ;;    ((and org-mw-table-use-header-tags-for-first-column
-  ;;      (zerop (cdr (org-export-table-cell-address table-cell info))))
-  ;;     (concat "\n" (format (car org-mw-table-header-tags) "row" cell-attrs)
-  ;;         contents (cdr org-mw-table-header-tags)))
-  ;;    (t (concat "\n" (format (car org-mw-table-data-tags) cell-attrs)
-  ;;   	contents (cdr org-mw-table-data-tags))))))
 
 ;;;; Table Row
 
@@ -558,43 +509,6 @@ channel."
 CONTENTS is the contents of the row.  INFO is a plist used as a
 communication channel."
   (concat "|-\n" contents))
-  ;; ;; Rules are ignored since table separators are deduced from
-  ;; ;; borders of the current row.
-  ;; (when (eq (org-element-property :type table-row) 'standard)
-  ;;   (let* ((rowgroup-number (org-export-table-row-group table-row info))
-  ;;      (row-number (org-export-table-row-number table-row info))
-  ;;      (start-rowgroup-p
-  ;;       (org-export-table-row-starts-rowgroup-p table-row info))
-  ;;      (end-rowgroup-p
-  ;;       (org-export-table-row-ends-rowgroup-p table-row info))
-  ;;      ;; `top-row-p' and `end-rowgroup-p' are not used directly
-  ;;      ;; but should be set so that `org-mw-table-row-tags' can
-  ;;      ;; use them (see the docstring of this variable.)
-  ;;      (top-row-p (and (equal start-rowgroup-p '(top))
-  ;;   		   (equal end-rowgroup-p '(below top))))
-  ;;      (bottom-row-p (and (equal start-rowgroup-p '(above))
-  ;;   		      (equal end-rowgroup-p '(bottom above))))
-  ;;      (rowgroup-tags
-  ;;       (cond
-  ;;        ;; Case 1: Row belongs to second or subsequent rowgroups.
-  ;;        ((not (= 1 rowgroup-number))
-  ;;         '("<tbody>" . "\n</tbody>"))
-  ;;        ;; Case 2: Row is from first rowgroup.  Table has >=1 rowgroups.
-  ;;        ((org-export-table-has-header-p
-  ;;          (org-export-get-parent-table table-row) info)
-  ;;         '("<thead>" . "\n</thead>"))
-  ;;        ;; Case 2: Row is from first and only row group.
-  ;;        (t '("<tbody>" . "\n</tbody>")))))
-  ;;     (concat
-  ;;      ;; Begin a rowgroup?
-  ;;      (when start-rowgroup-p (car rowgroup-tags))
-  ;;      ;; Actual table row
-  ;;      (concat "\n" (eval (car org-mw-table-row-tags))
-  ;;          contents
-  ;;          "\n"
-  ;;          (eval (cdr org-mw-table-row-tags)))
-  ;;      ;; End a rowgroup?
-  ;;      (when end-rowgroup-p (cdr rowgroup-tags))))))
 
 ;;;; Table
 
@@ -602,11 +516,11 @@ communication channel."
   "Transcode the first row of TABLE.
 INFO is a plist used as a communication channel."
   (let ((table-row
-	 (org-element-map table 'table-row
-	   (lambda (row)
-	     (unless (eq (org-element-property :type row) 'rule) row))
-	   info 'first-match))
-	(special-column-p (org-export-table-has-special-column-p table)))
+         (org-element-map table 'table-row
+           (lambda (row)
+             (unless (eq (org-element-property :type row) 'rule) row))
+           info 'first-match))
+        (special-column-p (org-export-table-has-special-column-p table)))
     (if (not special-column-p) (org-element-contents table-row)
       (cdr (org-element-contents table-row)))))
 
@@ -616,16 +530,16 @@ INFO is a plist used as a communication channel."
   (when (eq (org-element-property :type table) 'table.el)
     (require 'table)
     (let ((outbuf (with-current-buffer
-		      (get-buffer-create "*org-export-table*")
-		    (erase-buffer) (current-buffer))))
+                      (get-buffer-create "*org-export-table*")
+                    (erase-buffer) (current-buffer))))
       (with-temp-buffer
-	(insert (org-element-property :value table))
-	(goto-char 1)
-	(re-search-forward "^[ \t]*|[^|]" nil t)
-	(table-generate-source 'html outbuf))
+        (insert (org-element-property :value table))
+        (goto-char 1)
+        (re-search-forward "^[ \t]*|[^|]" nil t)
+        (table-generate-source 'html outbuf))
       (with-current-buffer outbuf
-	(prog1 (org-trim (buffer-string))
-	  (kill-buffer) )))))
+        (prog1 (org-trim (buffer-string))
+          (kill-buffer) )))))
 
 (defun org-mw-table (table contents info)
   "Transcode a TABLE element from Org to HTML.
@@ -649,17 +563,6 @@ contextual information."
                  (lambda (table-cell)
                    (let ((alignment (org-export-table-cell-alignment
                                      table-cell info)))
-                     ;; (concat
-                     ;;  ;; Begin a colgroup?
-                     ;;  (when (org-export-table-cell-starts-colgroup-p
-                     ;;         table-cell info)
-                     ;;    "\n<colgroup>")
-                     ;;  ;; Add a column.  Also specify it's alignment.
-                     ;;  (format "\n<col %s/>" (format alignspec alignment))
-                     ;;  ;; End a colgroup?
-                     ;;  (when (org-export-table-cell-ends-colgroup-p
-                     ;;         table-cell info)
-                     ;;    "\n</colgroup>"))
                      ""
                      ))
                  (org-mw-table-first-row-data-cells table info) "\n"))))) ;; End of Let*
@@ -710,19 +613,19 @@ non-nil."
   (interactive)
   (if async
       (org-export-async-start
-	  (lambda (output)
-	    (with-current-buffer (get-buffer-create "*Org MW Export*")
-	      (erase-buffer)
-	      (insert output)
-	      (goto-char (point-min))
-	      (text-mode)
-	      (org-export-add-to-stack (current-buffer) 'mw)))
-	`(org-export-as 'mw ,subtreep ,visible-only))
+          (lambda (output)
+            (with-current-buffer (get-buffer-create "*Org MW Export*")
+              (erase-buffer)
+              (insert output)
+              (goto-char (point-min))
+              (text-mode)
+              (org-export-add-to-stack (current-buffer) 'mw)))
+        `(org-export-as 'mw ,subtreep ,visible-only))
     (let ((outbuf (org-export-to-buffer
-		   'mw "*Org MW Export*" subtreep visible-only)))
+                      'mw "*Org MW Export*" subtreep visible-only)))
       (with-current-buffer outbuf (text-mode))
       (when org-export-show-temporary-export-buffer
-	(switch-to-buffer-other-window outbuf)))))
+        (switch-to-buffer-other-window outbuf)))))
 
 ;;;###autoload
 (defun org-mw-convert-region-to-mw ()
@@ -758,10 +661,10 @@ Return output file's name."
   (interactive)
   (let ((outfile (org-export-output-file-name ".mw" subtreep)))
     (if async
-	(org-export-async-start
-	    (lambda (f) (org-export-add-to-stack f 'mw))
-	  `(expand-file-name
-	    (org-export-to-file 'mw ,outfile ,subtreep ,visible-only)))
+ (org-export-async-start
+            (lambda (f) (org-export-add-to-stack f 'mw))
+          `(expand-file-name
+            (org-export-to-file 'mw ,outfile ,subtreep ,visible-only)))
       (org-export-to-file 'mw outfile subtreep visible-only))))
 
 


### PR DESCRIPTION
__WIP!__

## Issues

1. links broken across lines weren't exported properly

    ```org
    [[target][some 
    link]]
    ```
2. underlines resulted in error
    
    ```org
    _test_
    ```

3. plain lists had every line prefixed with `#`

    ```org
    1. an item
       with a wrap
    2. a second item
       with a wrap
    ```

## Fixes

1. join CONTENTS in links.
2. Use CONTENTS in verbatim.
3. join the body of plain list items.

## Notes

In general whitespace was all over the place in this file. I did a global indent on it.

## Help needed

At the moment, this backend still inserts newlines between plain list items. This makes the new lists for each item in mediawiki. It'd be great if, like the ox-md.el, we could have this chomp the newlines so we get one list.
