### PR TITLE
Remove :export-block tag, not supported anymore in Orgmode 9.0

### DIFF
--- a/ox-mediawiki.el
+++ b/ox-mediawiki.el
@@ -93,7 +93,6 @@ by the footnotes themselves."
 ;;; Define Back-End
 
 (org-export-define-derived-backend 'mw 'html
-  :export-block '("MW" "MEDIAWIKI")
   :filters-alist '((:filter-parse-tree . org-mw-separate-elements))
   :menu-entry
   '(?m "Export to Mediawiki"


### PR DESCRIPTION
Hi!

Orgmode 9.0 removed :export-block tags, which are not supported anymore. This PR makes orgmode-mediawiki compatible with Orgmode 9.0.